### PR TITLE
allow radio to access IOemSlsiRadioExternal hwservice

### DIFF
--- a/whitechapel_pro/radio.te
+++ b/whitechapel_pro/radio.te
@@ -1,2 +1,4 @@
+allow radio hal_exynos_rild_hwservice:hwservice_manager find;
+
 allow radio proc_vendor_sched:dir r_dir_perms;
 allow radio proc_vendor_sched:file w_file_perms;


### PR DESCRIPTION
It's needed for system_ext/app/OemRilHookService which runs in the radio domain.

OemRilHookService publishes "telephony.oem.oemrilhook" service and tries to connect to IOemSlsiRadioExternal when handling calls to this service.

In some cases, OemRilHookService started to retry access to IOemSlsiRadioExternal tens of times per minute for multiple hours, which led to excessive battery drain.